### PR TITLE
8bit Optimisers and resolved potential setup.py issues

### DIFF
--- a/muse_maskgit_pytorch/trainers/maskgit_trainer.py
+++ b/muse_maskgit_pytorch/trainers/maskgit_trainer.py
@@ -107,12 +107,26 @@ class MaskGitTrainer(BaseAcceleratedTrainer):
         # optimizers
         if optimizer == "Adam":
             if use_8bit_adam:
-                self.optim = bnb.optim.Adam8bit(transformer_parameters, lr=lr, weight_decay=weight_decay)
+                try:
+                    self.optim = bnb.optim.Adam8bit(transformer_parameters, lr=lr, weight_decay=weight_decay)
+                except Exception as e:  # bitsandbytes raises a broad exception for cuda setup errors
+                    error = str(e)
+                    if "CUDA SETUP" in error:
+                        self.optim = Adam(transformer_parameters, lr=lr, weight_decay=weight_decay)
+                    else:
+                        raise e
             else:
                 self.optim = Adam(transformer_parameters, lr=lr, weight_decay=weight_decay)
         elif optimizer == "AdamW":
             if use_8bit_adam:
-                self.optim = bnb.optim.AdamW8bit(transformer_parameters, lr=lr, weight_decay=weight_decay)
+                try:
+                    self.optim = bnb.optim.AdamW8bit(transformer_parameters, lr=lr, weight_decay=weight_decay)
+                except Exception as e:  # bitsandbytes raises a broad exception for cuda setup errors
+                    error = str(e)
+                    if "CUDA SETUP" in error:
+                        self.optim = Adam(transformer_parameters, lr=lr, weight_decay=weight_decay)
+                    else:
+                        raise e
             else:
                 self.optim = AdamW(transformer_parameters, lr=lr, weight_decay=weight_decay)
         elif optimizer == "Lion":

--- a/muse_maskgit_pytorch/trainers/maskgit_trainer.py
+++ b/muse_maskgit_pytorch/trainers/maskgit_trainer.py
@@ -118,7 +118,7 @@ class MaskGitTrainer(BaseAcceleratedTrainer):
         elif optimizer == "Lion":
             self.optim = Lion(transformer_parameters, lr=lr, weight_decay=weight_decay)
             if use_8bit_adam:
-                print("8bit is not supported with the Lion optimiser, Using standard Lion instead.")
+                print("8bit is not supported by the Lion optimiser, Using standard Lion instead.")
         else:
             print(f"{optimizer} optimizer not supported yet.")
 

--- a/muse_maskgit_pytorch/trainers/maskgit_trainer.py
+++ b/muse_maskgit_pytorch/trainers/maskgit_trainer.py
@@ -107,12 +107,12 @@ class MaskGitTrainer(BaseAcceleratedTrainer):
         # optimizers
         if optimizer == "Adam":
             if use_8bit_adam:
-                self.optim = bnb.optim.Adam8bit(transformer_parameters, lr=lr)
+                self.optim = bnb.optim.Adam8bit(transformer_parameters, lr=lr, weight_decay=weight_decay)
             else:
                 self.optim = Adam(transformer_parameters, lr=lr, weight_decay=weight_decay)
         elif optimizer == "AdamW":
             if use_8bit_adam:
-                self.optim = bnb.optim.AdamW8bit(transformer_parameters, lr=lr)
+                self.optim = bnb.optim.AdamW8bit(transformer_parameters, lr=lr, weight_decay=weight_decay)
             else:
                 self.optim = AdamW(transformer_parameters, lr=lr, weight_decay=weight_decay)
         elif optimizer == "Lion":

--- a/muse_maskgit_pytorch/trainers/vqvae_trainers.py
+++ b/muse_maskgit_pytorch/trainers/vqvae_trainers.py
@@ -104,15 +104,31 @@ class VQGanVAETrainer(BaseAcceleratedTrainer):
         # optimizers
         if optimizer == 'Adam':
             if use_8bit_adam:
-                self.optim = bnb.optim.Adam8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
-                self.discr_optim = bnb.optim.Adam8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
+                try:
+                    self.optim = bnb.optim.Adam8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
+                    self.discr_optim = bnb.optim.Adam8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
+                except Exception as e:  # bitsandbytes raises a broad exception for cuda setup errors
+                    error = str(e)
+                    if "CUDA SETUP" in error:
+                        self.optim = Adam(vae_parameters, lr=lr, weight_decay=weight_decay)
+                        self.discr_optim = Adam(discr_parameters, lr=lr, weight_decay=weight_decay)
+                    else:
+                        raise e
             else:
                 self.optim = Adam(vae_parameters, lr=lr, weight_decay=weight_decay)
                 self.discr_optim = Adam(discr_parameters, lr=lr, weight_decay=weight_decay)
         elif optimizer == 'AdamW':
             if use_8bit_adam:
-                self.optim = bnb.optim.AdamW8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
-                self.discr_optim = bnb.optim.AdamW8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
+                try:
+                    self.optim = bnb.optim.AdamW8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
+                    self.discr_optim = bnb.optim.AdamW8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
+                except Exception as e:  # bitsandbytes raises a broad exception for cuda setup errors
+                    error = str(e)
+                    if "CUDA SETUP" in error:
+                        self.optim = AdamW(vae_parameters, lr=lr, weight_decay=weight_decay)
+                        self.discr_optim = AdamW(discr_parameters, lr=lr, weight_decay=weight_decay)
+                    else:
+                        raise e
             else:
                 self.optim = AdamW(vae_parameters, lr=lr, weight_decay=weight_decay)
                 self.discr_optim = AdamW(discr_parameters, lr=lr, weight_decay=weight_decay)

--- a/muse_maskgit_pytorch/trainers/vqvae_trainers.py
+++ b/muse_maskgit_pytorch/trainers/vqvae_trainers.py
@@ -120,7 +120,7 @@ class VQGanVAETrainer(BaseAcceleratedTrainer):
             self.optim = Lion(vae_parameters, lr=lr, weight_decay=weight_decay)
             self.discr_optim = Lion(discr_parameters, lr=lr, weight_decay=weight_decay)
             if use_8bit_adam:
-                print("8bit is not supported with the Lion optimiser, Using standard Lion instead.")
+                print("8bit is not supported by the Lion optimiser, Using standard Lion instead.")
         else:
             print(f"{optimizer} optimizer not supported yet.")
 

--- a/muse_maskgit_pytorch/trainers/vqvae_trainers.py
+++ b/muse_maskgit_pytorch/trainers/vqvae_trainers.py
@@ -13,7 +13,6 @@ from lion_pytorch import Lion
 from torch.utils.data import DataLoader, random_split
 from torch.utils.tensorboard import SummaryWriter
 from torchvision.utils import make_grid, save_image
-import bitsandbytes as bnb
 
 from muse_maskgit_pytorch.vqgan_vae import VQGanVAE
 
@@ -105,33 +104,33 @@ class VQGanVAETrainer(BaseAcceleratedTrainer):
         if optimizer == 'Adam':
             if use_8bit_adam:
                 try:
+                    import bitsandbytes as bnb
                     self.optim = bnb.optim.Adam8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
                     self.discr_optim = bnb.optim.Adam8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
-                except Exception as e:  # bitsandbytes raises a broad exception for cuda setup errors
-                    error = str(e)
-                    if "CUDA SETUP" in error:
-                        self.optim = Adam(vae_parameters, lr=lr, weight_decay=weight_decay)
-                        self.discr_optim = Adam(discr_parameters, lr=lr, weight_decay=weight_decay)
-                    else:
-                        raise e
+                except ImportError:
+                    print("Please install bitsandbytes to use 8-bit optimizers. You can do so by running `pip install "
+                          "bitsandbytes` | Defaulting to non 8-bit equivalent...")
+                    self.optim = Adam(vae_parameters, lr=lr, weight_decay=weight_decay)
+                    self.discr_optim = Adam(discr_parameters, lr=lr, weight_decay=weight_decay)
             else:
                 self.optim = Adam(vae_parameters, lr=lr, weight_decay=weight_decay)
                 self.discr_optim = Adam(discr_parameters, lr=lr, weight_decay=weight_decay)
+
         elif optimizer == 'AdamW':
             if use_8bit_adam:
                 try:
+                    import bitsandbytes as bnb
                     self.optim = bnb.optim.AdamW8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
                     self.discr_optim = bnb.optim.AdamW8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
-                except Exception as e:  # bitsandbytes raises a broad exception for cuda setup errors
-                    error = str(e)
-                    if "CUDA SETUP" in error:
-                        self.optim = AdamW(vae_parameters, lr=lr, weight_decay=weight_decay)
-                        self.discr_optim = AdamW(discr_parameters, lr=lr, weight_decay=weight_decay)
-                    else:
-                        raise e
+                except ImportError:
+                    print("Please install bitsandbytes to use 8-bit optimizers. You can do so by running `pip install "
+                          "bitsandbytes` | Defaulting to non 8-bit equivalent...")
+                    self.optim = AdamW(vae_parameters, lr=lr, weight_decay=weight_decay)
+                    self.discr_optim = AdamW(discr_parameters, lr=lr, weight_decay=weight_decay)
             else:
                 self.optim = AdamW(vae_parameters, lr=lr, weight_decay=weight_decay)
                 self.discr_optim = AdamW(discr_parameters, lr=lr, weight_decay=weight_decay)
+
         elif optimizer == 'Lion':
             self.optim = Lion(vae_parameters, lr=lr, weight_decay=weight_decay)
             self.discr_optim = Lion(discr_parameters, lr=lr, weight_decay=weight_decay)

--- a/muse_maskgit_pytorch/trainers/vqvae_trainers.py
+++ b/muse_maskgit_pytorch/trainers/vqvae_trainers.py
@@ -13,7 +13,7 @@ from lion_pytorch import Lion
 from torch.utils.data import DataLoader, random_split
 from torch.utils.tensorboard import SummaryWriter
 from torchvision.utils import make_grid, save_image
-
+import bitsandbytes as bnb
 
 from muse_maskgit_pytorch.vqgan_vae import VQGanVAE
 
@@ -74,6 +74,7 @@ class VQGanVAETrainer(BaseAcceleratedTrainer):
         only_save_last_checkpoint=False,
         optimizer='Adam',
         weight_decay=0.0,
+        use_8bit_adam=False
     ):
         super().__init__(
             dataloader,
@@ -102,14 +103,24 @@ class VQGanVAETrainer(BaseAcceleratedTrainer):
 
         # optimizers
         if optimizer == 'Adam':
-            self.optim = Adam(vae_parameters, lr=lr, weight_decay=weight_decay)
-            self.discr_optim = Adam(discr_parameters, lr=lr, weight_decay=weight_decay)
+            if use_8bit_adam:
+                self.optim = bnb.optim.Adam8bit(vae_parameters, lr=lr)
+                self.discr_optim = bnb.optim.Adam8bit(discr_parameters, lr=lr)
+            else:
+                self.optim = Adam(vae_parameters, lr=lr)
+                self.discr_optim = Adam(discr_parameters, lr=lr)
         elif optimizer == 'AdamW':
-                self.optim = AdamW(vae_parameters, lr=lr, weight_decay=weight_decay)
-                self.discr_optim = AdamW(discr_parameters, lr=lr)            
+            if use_8bit_adam:
+                self.optim = bnb.optim.AdamW8bit(vae_parameters, lr=lr)
+                self.discr_optim = bnb.optim.AdamW8bit(discr_parameters, lr=lr)
+            else:
+                self.optim = AdamW(vae_parameters, lr=lr)
+                self.discr_optim = AdamW(discr_parameters, lr=lr)
         elif optimizer == 'Lion':
             self.optim = Lion(vae_parameters, lr=lr, weight_decay=weight_decay)
             self.discr_optim = Lion(discr_parameters, lr=lr, weight_decay=weight_decay)
+            if use_8bit_adam:
+                print("8bit is not supported with the Lion optimiser, Using standard Lion instead.")
         else:
             print(f"{optimizer} optimizer not supported yet.")
 

--- a/muse_maskgit_pytorch/trainers/vqvae_trainers.py
+++ b/muse_maskgit_pytorch/trainers/vqvae_trainers.py
@@ -104,18 +104,18 @@ class VQGanVAETrainer(BaseAcceleratedTrainer):
         # optimizers
         if optimizer == 'Adam':
             if use_8bit_adam:
-                self.optim = bnb.optim.Adam8bit(vae_parameters, lr=lr)
-                self.discr_optim = bnb.optim.Adam8bit(discr_parameters, lr=lr)
+                self.optim = bnb.optim.Adam8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
+                self.discr_optim = bnb.optim.Adam8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
             else:
-                self.optim = Adam(vae_parameters, lr=lr)
-                self.discr_optim = Adam(discr_parameters, lr=lr)
+                self.optim = Adam(vae_parameters, lr=lr, weight_decay=weight_decay)
+                self.discr_optim = Adam(discr_parameters, lr=lr, weight_decay=weight_decay)
         elif optimizer == 'AdamW':
             if use_8bit_adam:
-                self.optim = bnb.optim.AdamW8bit(vae_parameters, lr=lr)
-                self.discr_optim = bnb.optim.AdamW8bit(discr_parameters, lr=lr)
+                self.optim = bnb.optim.AdamW8bit(vae_parameters, lr=lr, weight_decay=weight_decay)
+                self.discr_optim = bnb.optim.AdamW8bit(discr_parameters, lr=lr, weight_decay=weight_decay)
             else:
-                self.optim = AdamW(vae_parameters, lr=lr)
-                self.discr_optim = AdamW(discr_parameters, lr=lr)
+                self.optim = AdamW(vae_parameters, lr=lr, weight_decay=weight_decay)
+                self.discr_optim = AdamW(discr_parameters, lr=lr, weight_decay=weight_decay)
         elif optimizer == 'Lion':
             self.optim = Lion(vae_parameters, lr=lr, weight_decay=weight_decay)
             self.discr_optim = Lion(discr_parameters, lr=lr, weight_decay=weight_decay)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         "pillow",
         "sentencepiece",
         "torch>=1.6",
+        "torchmetrics<0.8.0",
+        "pytorch-lightning<=1.7.7",
         "taming-transformers>=0.0.1",
         "transformers",
         "torch>=1.6",

--- a/train_muse_maskgit.py
+++ b/train_muse_maskgit.py
@@ -141,6 +141,11 @@ def parse_args():
         help="Precision to train on.",
     )
     parser.add_argument(
+        "--use_8bit_adam",
+        action="store_true",
+        help="Whether to use the 8bit adam optimiser",
+    )
+    parser.add_argument(
         "--results_dir",
         type=str,
         default="results",
@@ -384,6 +389,7 @@ def main():
         only_save_last_checkpoint=args.only_save_last_checkpoint,
         optimizer=args.optimizer,
         weight_decay=args.weight_decay,
+        use_8bit_adam=args.use_8bit_adam
     )
 
     trainer.train()

--- a/train_muse_vae.py
+++ b/train_muse_vae.py
@@ -13,6 +13,9 @@ from muse_maskgit_pytorch.dataset import (
 
 import argparse
 
+import torch.nn as nn
+import bitsandbytes as bnb
+from accelerate import init_empty_weights
 
 def parse_args():
     # Create the parser
@@ -111,6 +114,11 @@ def parse_args():
         help="Precision to train on.",
     )
     parser.add_argument(
+        "--use_8bit_adam",
+        action="store_true",
+        help="Whether to use the 8bit adam optimiser",
+    )
+    parser.add_argument(
         "--results_dir",
         type=str,
         default="results",
@@ -188,15 +196,17 @@ def parse_args():
         default=None,
         help="Path to the last saved checkpoint. 'results/vae.steps.pt'",
     )
-    parser.add_argument("--optimizer",type=str,
+    parser.add_argument(
+        "--optimizer",type=str,
         default='Lion',
         help="Optimizer to use. Choose between: ['Adam', 'AdamW','Lion']. Default: Adam",
-    )    
-    parser.add_argument("--weight_decay", type=float,
-                        default=0.0,
-                        help="Optimizer weight_decay to use. Default: 0.0",
-                        )    
-   
+    )
+    parser.add_argument(
+        "--weight_decay", type=float,
+        default=0.0,
+        help="Optimizer weight_decay to use. Default: 0.0",
+    )
+
     # Parse the argument
     return parser.parse_args()
 
@@ -288,6 +298,7 @@ def main():
         validation_image_scale=args.validation_image_scale,
         only_save_last_checkpoint=args.only_save_last_checkpoint,
         optimizer=args.optimizer,
+        use_8bit_adam=args.use_8bit_adam
     )
 
     trainer.train()


### PR DESCRIPTION
The commit to setup.py was to resolve dependency issues on my machine, as certain features are deprecated in later versions of lightning and torchmetrics, these versions still have these features but present deprecation warnings, feel free to change these as you see necessary

Also, regarding 8bit, replacing `nn.Linear()` with its 8bit equivalent (`bnb.nn.Linear8bitLt()` | which seems to be only for inference) seems to break tensors, so I've opted for merely implementing the optimisers